### PR TITLE
Fix crash on middle-click of Extended label ACID item

### DIFF
--- a/Labels.xml
+++ b/Labels.xml
@@ -67,7 +67,7 @@
     <DataLine>	
 	  <Item Type="SELECT_VERT" />
       <Item Type="AURORA_COMM_ICON" Colour="" LeftClick="Label_CPDLC_Menu" MiddleClick="" RightClick="Label_CPDLC_Editor" MinLength="2" LeaderLineAnchor = "true"/>		  
-      <Item Type="LABEL_ITEM_ACID" Colour="" P1_Colour="" P2_Colour="" LeftClick="Label_Move" MiddleClick="Label_Warning" RightClick="Label_ACID_Menu" LeftPadding="1" MaxLength="7" MinLength="7"/>	  
+      <Item Type="LABEL_ITEM_ACID" Colour="" P1_Colour="" P2_Colour="" LeftClick="Label_Move" MiddleClick="Label_Extend_Toggle" RightClick="Label_ACID_Menu" LeftPadding="1" MaxLength="7" MinLength="7"/>	  
       <Item Type="AURORA_ADSB_CPDLC" Colour="" LeftClick="Label_Move" MiddleClick="" RightClick="" LeftPadding="1" MinLength="3" FontSize="XtraLarge"/>
       <Item Type="AURORA_ADS_FLAGS" Colour="" LeftClick="" MiddleClick="" RightClick="" LeftPadding="1" MinLength="3"/>
       <Item Type="AURORA_MNT_FLAGS" Colour="" LeftClick="" MiddleClick="" RightClick="" LeftPadding="1" MinLength="3"/>


### PR DESCRIPTION
The Extended label's LABEL_ITEM_ACID had MiddleClick="Label_Warning" which causes an InvalidCastException when middle-clicked, crashing vatSys with "Error rendering tracks layer". Changed to Label_Extend_Toggle to match the Normal label's ACID behavior.